### PR TITLE
Minor readme change

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ SlimLogger tries to be as lean as possible, but still flexible enough to fit the
   
 ##Installation
 
-  * Add `SlimLogger.swift` and `SlimLoggerConfig.template` to your project
-  * Rename `SlimLoggerConfig.template` to `SlimLoggerConfig.swift`
+  1. Rename `SlimLoggerConfig.template` to `SlimLoggerConfig.swift`
+  2. Add `SlimLogger.swift` and `SlimLoggerConfig.swift` to your project
   
 ##Configuration
 


### PR DESCRIPTION
If I follow the steps as is (first add to project, then rename the file), the environment can't locate the `SlimConfig` object.

Works better to rename the file first, then add it to the project. Might resolve itself by restarting xcode, I didn't check, but there's probably less friction to just do the steps in this order.
